### PR TITLE
fix(bugfix): fixed the bug discovered when updating Border width slice' names

### DIFF
--- a/src/plugin/page-generation/utils.test.ts
+++ b/src/plugin/page-generation/utils.test.ts
@@ -1,5 +1,5 @@
 import { Slices } from '../../_shared/constants';
-import { createInstances, getVariantCombinations } from './utils';
+import { createInstances, getVariantCombinations, updateVariantName } from './utils';
 
 describe('get variants', () => {
   it('should return expected combinations', () => {
@@ -72,5 +72,23 @@ describe('createInstances', () => {
         Y: `${instances[2].id}/#/${instances[3].id}`,
       },
     });
+  });
+});
+
+describe('updateVariantName', () => {
+  it('should replace the variant name for the provided slice, without mutating the input', () => {
+    const oldName = `${Slices.Radius}=S, ${Slices.BorderWidth}=F`;
+    const newName = updateVariantName({ instanceName: oldName, sliceName: Slices.Radius, newVariantName: 'A' });
+    const newName2 = updateVariantName({
+      instanceName: oldName,
+      sliceName: Slices.BorderWidth,
+      newVariantName: 'none',
+    });
+
+    const expectedName = `${Slices.Radius}=A, ${Slices.BorderWidth}=F`;
+    const expectedName2 = `${Slices.Radius}=S, ${Slices.BorderWidth}=none`;
+
+    expect(newName).toBe(expectedName);
+    expect(newName2).toBe(expectedName2);
   });
 });

--- a/src/plugin/pluginControllers.ts
+++ b/src/plugin/pluginControllers.ts
@@ -14,7 +14,7 @@ import {
 } from './page-generation/utils';
 
 export const controllers: Record<PluginActionTypes, Resolver> = {
-  'generate-theme': () => {
+  [ActionTypes.generateTheme]: () => {
     const localPaintStyles = figma.getLocalPaintStyles();
     const normalizedColors = colorNormalizer(localPaintStyles);
 
@@ -24,7 +24,7 @@ export const controllers: Record<PluginActionTypes, Resolver> = {
     });
   },
 
-  'sync-theme': () => {
+  [ActionTypes.syncTheme]: () => {
     const themePage = figma.root.children.find((node) => node.name === THEME_PAGE_NAME);
     if (!themePage) {
       figma.notify(
@@ -80,7 +80,7 @@ export const controllers: Record<PluginActionTypes, Resolver> = {
     figma.notify('Components updated!');
   },
 
-  'generate-theme-page': () => {
+  [ActionTypes.generateThemePage]: () => {
     const themePage = figma.root.children.find((node) => node.name === THEME_PAGE_NAME);
     if (themePage) {
       figma.notify(`The '${THEME_PAGE_NAME}' page already exist`, { error: true, timeout: 5000 });


### PR DESCRIPTION
# Proposed changes

Basically the problem was a wrong regex (it was matching everything between `Border width=` and `,` but since at the moment Border width is the last one, on the name there's no comma at the end) 

So I added a updateVariantName utility and a test case, changing the regex with another one

closes #14

## Types of changes

- [ ] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [x] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✅ Tests (added tests for an existing feature)
- [ ] 📚 Chore / Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [x] :scissors: I have ensured that the PR is concise and broken down if needed
- [x] 👀 I have read the [README](../README.md) doc
- [x] 🧪 I have added tests that prove my fix is effective or that my feature works
- [ ] 📚 I have added necessary documentation (if appropriate)
- [x] 🔀 Any dependent changes have been merged and published in downstream modules
