### PR TITLE
feat(core): updated syncTheme to detect deleted slice variants and remove related component instances

### DIFF
--- a/__mocks__/mockUtils.ts
+++ b/__mocks__/mockUtils.ts
@@ -1,9 +1,9 @@
-export const mockPageNode = (overrides?: Partial<PageNode>) => {
+export const mockNode = <T extends BaseNode>(overrides?: Partial<T>) => {
   return {
     id: `${Math.random()}`,
     appendChild: jest.fn(),
     setSharedPluginData: jest.fn(),
     getSharedPluginData: jest.fn(),
     ...overrides,
-  } as PageNode;
+  } as unknown as T;
 };

--- a/__mocks__/mockUtils.ts
+++ b/__mocks__/mockUtils.ts
@@ -1,0 +1,9 @@
+export const mockPageNode = (overrides?: Partial<PageNode>) => {
+  return {
+    id: `${Math.random()}`,
+    appendChild: jest.fn(),
+    setSharedPluginData: jest.fn(),
+    getSharedPluginData: jest.fn(),
+    ...overrides,
+  } as PageNode;
+};

--- a/src/_shared/constants.ts
+++ b/src/_shared/constants.ts
@@ -3,6 +3,8 @@ export const THEME_PAGE_NAME = '#Morfeo theme';
 
 export enum PluginDataKeys {
   boxRefId = 'box-ref-id',
+  currentRadiiVariants = 'current-radii-variants',
+  currentBorderWidthVariants = 'current-border-width-variants',
 }
 
 export enum SliceFrameNames {

--- a/src/plugin/createMorfeoTheme/createMorfeoTheme.ts
+++ b/src/plugin/createMorfeoTheme/createMorfeoTheme.ts
@@ -7,7 +7,7 @@ import {
 } from '../../_shared/constants';
 import { Controller } from '../../_shared/types/contoller';
 import { createBorderWidthSlices, createRadiiSlices } from '../generateTheme/utils';
-import { getNewFrame, getVariantCombinations, createInstances, setRefs } from '../utils/utils';
+import { getNewFrame, getVariantCombinations, createInstances, setRefs, saveCurrentBoxVariants } from '../utils/utils';
 
 export const createMorfeoTheme: Controller = () => {
   const themePage = figma.root.children.find((node) => node.name === THEME_PAGE_NAME);
@@ -46,6 +46,16 @@ export const createMorfeoTheme: Controller = () => {
   // set the ref ids
   setRefs({ refIds: boxVariants.refIds[Slices.Radius], slices: radiiSlices });
   setRefs({ refIds: boxVariants.refIds[Slices.BorderWidth], slices: borderWidthSlices });
+  saveCurrentBoxVariants({
+    themePage: page,
+    refIds: boxVariants.refIds[Slices.Radius],
+    pluginKey: PluginDataKeys.currentRadiiVariants,
+  });
+  saveCurrentBoxVariants({
+    themePage: page,
+    refIds: boxVariants.refIds[Slices.BorderWidth],
+    pluginKey: PluginDataKeys.currentBorderWidthVariants,
+  });
 
   box.resize(140, 140);
   boxComponent.clipsContent = false;

--- a/src/plugin/syncTheme/syncTheme.ts
+++ b/src/plugin/syncTheme/syncTheme.ts
@@ -40,7 +40,6 @@ export const syncTheme: Controller = () => {
       error: true,
       timeout: 3000,
     });
-    figma.closePlugin();
     return;
   }
 

--- a/src/plugin/syncTheme/utils.test.ts
+++ b/src/plugin/syncTheme/utils.test.ts
@@ -1,7 +1,204 @@
-import { mockPageNode } from '../../../__mocks__/mockUtils';
+import { mockGetNodeById, mockNotify } from '../../../__mocks__/figmaMock';
+import { mockNode } from '../../../__mocks__/mockUtils';
 import { PluginDataKeys } from '../../_shared/constants';
 import * as GlobalUtils from '../utils/utils';
-import { checkAndRemoveDeletedSlices } from './utils';
+import { checkAndRemoveDeletedSlices, syncBorderWidthVariants, syncRadiiVariants } from './utils';
+
+describe('syncRadiiVariants', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should return existent slices and new slices', () => {
+    mockGetNodeById.mockReturnValue(mockNode<ComponentNode>({ type: 'COMPONENT', name: '' }));
+    const radiiFrame = {
+      children: [
+        mockNode<RectangleNode>({
+          type: 'RECTANGLE',
+          cornerRadius: 1,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => '11:22/#/33:44'),
+        }),
+        mockNode<RectangleNode>({
+          type: 'RECTANGLE',
+          cornerRadius: 2,
+          name: 'M',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentRadiusSlices, newRadiusSlices } = syncRadiiVariants(radiiFrame);
+
+    expect(existentRadiusSlices).toEqual({ S: 1 });
+    expect(newRadiusSlices).toEqual({ M: 2 });
+  });
+
+  it('should ignore non-rectangle children', () => {
+    const radiiFrame = {
+      children: [
+        mockNode<LineNode>({
+          type: 'LINE',
+          name: 'S',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentRadiusSlices, newRadiusSlices } = syncRadiiVariants(radiiFrame);
+
+    expect(existentRadiusSlices).toEqual({});
+    expect(newRadiusSlices).toEqual({});
+    expect(radiiFrame.children[0].getSharedPluginData).not.toBeCalled();
+  });
+
+  it('should notify the user if he used mixed values for corner radius', () => {
+    const radiiFrame = {
+      children: [
+        mockNode<RectangleNode>({
+          type: 'RECTANGLE',
+          cornerRadius: figma.mixed,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentRadiusSlices, newRadiusSlices } = syncRadiiVariants(radiiFrame);
+
+    expect(existentRadiusSlices).toEqual({});
+    expect(newRadiusSlices).toEqual({});
+    expect(mockNotify).toBeCalledTimes(1);
+    expect(mockNotify).toBeCalledWith('Mixed border radius is not allowed on Slices', { error: true });
+  });
+
+  it('should notify the user if there are two slices with the same name', () => {
+    mockGetNodeById.mockReturnValue(mockNode<ComponentNode>({ type: 'COMPONENT', name: '' }));
+    const radiiFrame = {
+      children: [
+        mockNode<RectangleNode>({
+          type: 'RECTANGLE',
+          cornerRadius: 1,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => '11:22'),
+        }),
+        mockNode<RectangleNode>({
+          type: 'RECTANGLE',
+          cornerRadius: 2,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentRadiusSlices, newRadiusSlices } = syncRadiiVariants(radiiFrame);
+
+    expect(existentRadiusSlices).toEqual({ S: 1 });
+    expect(newRadiusSlices).toEqual({});
+    expect(mockNotify).toBeCalledTimes(1);
+    expect(mockNotify).toBeCalledWith('The S variant on Radii already exist, please use a unique name', {
+      error: true,
+      timeout: 2000,
+    });
+  });
+});
+
+describe('syncBorderWidthVariants', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should return existent slices and new slices', () => {
+    mockGetNodeById.mockReturnValue(mockNode<ComponentNode>({ type: 'COMPONENT', name: '' }));
+    const borderWidthFrame = {
+      children: [
+        mockNode<LineNode>({
+          type: 'LINE',
+          strokeWeight: 1,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => '11:22/#/33:44'),
+        }),
+        mockNode<LineNode>({
+          type: 'LINE',
+          strokeWeight: 2,
+          name: 'M',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentBorderWidthSlices, newBorderWidthSlices } = syncBorderWidthVariants(borderWidthFrame);
+
+    expect(existentBorderWidthSlices).toEqual({ S: 1 });
+    expect(newBorderWidthSlices).toEqual({ M: 2 });
+  });
+
+  it('should ignore non-line children', () => {
+    const borderWidthFrame = {
+      children: [
+        mockNode<RectangleNode>({
+          type: 'RECTANGLE',
+          name: 'S',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentBorderWidthSlices, newBorderWidthSlices } = syncBorderWidthVariants(borderWidthFrame);
+
+    expect(existentBorderWidthSlices).toEqual({});
+    expect(newBorderWidthSlices).toEqual({});
+    expect(borderWidthFrame.children[0].getSharedPluginData).not.toBeCalled();
+  });
+
+  it('should notify the user if he used mixed values for stroke weight', () => {
+    const borderWidthFrame = {
+      children: [
+        mockNode<LineNode>({
+          type: 'LINE',
+          strokeWeight: figma.mixed,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentBorderWidthSlices, newBorderWidthSlices } = syncBorderWidthVariants(borderWidthFrame);
+
+    expect(existentBorderWidthSlices).toEqual({});
+    expect(newBorderWidthSlices).toEqual({});
+    expect(mockNotify).toBeCalledTimes(1);
+    expect(mockNotify).toBeCalledWith('Mixed stroke weight is not allowed on Slices', { error: true });
+  });
+
+  it('should notify the user if there are two slices with the same name', () => {
+    mockGetNodeById.mockReturnValue(mockNode<ComponentNode>({ type: 'COMPONENT', name: '' }));
+    const borderWidthFrame = {
+      children: [
+        mockNode<LineNode>({
+          type: 'LINE',
+          strokeWeight: 1,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => '11:22'),
+        }),
+        mockNode<LineNode>({
+          type: 'LINE',
+          strokeWeight: 2,
+          name: 'S',
+          getSharedPluginData: jest.fn(() => ''),
+        }),
+      ],
+    } as unknown as FrameNode;
+
+    const { existentBorderWidthSlices, newBorderWidthSlices } = syncBorderWidthVariants(borderWidthFrame);
+
+    expect(existentBorderWidthSlices).toEqual({ S: 1 });
+    expect(newBorderWidthSlices).toEqual({});
+    expect(mockNotify).toBeCalledTimes(1);
+    expect(mockNotify).toBeCalledWith('The S variant on Border widths already exist, please use a unique name', {
+      error: true,
+      timeout: 2000,
+    });
+  });
+});
 
 const mockDeleteNodesById = jest.fn();
 jest.spyOn(GlobalUtils, 'deleteNodesById').mockImplementation(mockDeleteNodesById);
@@ -11,7 +208,7 @@ describe('checkAndRemoveDeletedSlices', () => {
     jest.clearAllMocks();
   });
   it('should call deleteNodesById and set updated variants if detect any deleted slices', () => {
-    const themePage = mockPageNode({
+    const themePage = mockNode<PageNode>({
       getSharedPluginData: jest.fn(() => JSON.stringify({ S: '12:12', M: '33:33', L: '44:11/#/44:22' })),
     });
     const existentSlicesKeys = ['S', 'M'];
@@ -29,7 +226,7 @@ describe('checkAndRemoveDeletedSlices', () => {
     expect(updatedSliceRefs).toEqual({ S: '12:12', M: '33:33' });
   });
   it('should do nothing if getSharedPluginData returns an empty string', () => {
-    const themePage = mockPageNode({ getSharedPluginData: jest.fn(() => '') });
+    const themePage = mockNode<PageNode>({ getSharedPluginData: jest.fn(() => '') });
     const updatedSliceRef = checkAndRemoveDeletedSlices({
       themePage,
       existentSlicesKeys: [],

--- a/src/plugin/syncTheme/utils.test.ts
+++ b/src/plugin/syncTheme/utils.test.ts
@@ -1,0 +1,42 @@
+import { mockPageNode } from '../../../__mocks__/mockUtils';
+import { PluginDataKeys } from '../../_shared/constants';
+import * as GlobalUtils from '../utils/utils';
+import { checkAndRemoveDeletedSlices } from './utils';
+
+const mockDeleteNodesById = jest.fn();
+jest.spyOn(GlobalUtils, 'deleteNodesById').mockImplementation(mockDeleteNodesById);
+
+describe('checkAndRemoveDeletedSlices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should call deleteNodesById and set updated variants if detect any deleted slices', () => {
+    const themePage = mockPageNode({
+      getSharedPluginData: jest.fn(() => JSON.stringify({ S: '12:12', M: '33:33', L: '44:11/#/44:22' })),
+    });
+    const existentSlicesKeys = ['S', 'M'];
+    const updatedSliceRefs = checkAndRemoveDeletedSlices({
+      themePage,
+      existentSlicesKeys,
+      pluginDataKey: PluginDataKeys.currentRadiiVariants,
+    });
+
+    // call deleteNodesById
+    expect(mockDeleteNodesById).toBeCalledTimes(1);
+    expect(mockDeleteNodesById).toBeCalledWith(['44:11', '44:22']);
+
+    // call setSharedPluginData with non-deleted variants
+    expect(updatedSliceRefs).toEqual({ S: '12:12', M: '33:33' });
+  });
+  it('should do nothing if getSharedPluginData returns an empty string', () => {
+    const themePage = mockPageNode({ getSharedPluginData: jest.fn(() => '') });
+    const updatedSliceRef = checkAndRemoveDeletedSlices({
+      themePage,
+      existentSlicesKeys: [],
+      pluginDataKey: PluginDataKeys.currentRadiiVariants,
+    });
+
+    expect(updatedSliceRef).toEqual({});
+    expect(mockDeleteNodesById).not.toBeCalled();
+  });
+});

--- a/src/plugin/syncTheme/utils.ts
+++ b/src/plugin/syncTheme/utils.ts
@@ -23,16 +23,16 @@ export const syncRadiiVariants = (radiiFrame: FrameNode) => {
       return;
     }
 
-    if (refIds[0] === '') {
-      newRadiusSlices[radiiSlice.name] = cornerRadius;
-      return;
-    }
-
     if (existentRadiusSlices[radiiSlice.name]) {
       figma.notify(`The ${radiiSlice.name} variant on Radii already exist, please use a unique name`, {
         error: true,
         timeout: 2000,
       });
+      return;
+    }
+
+    if (refIds[0] === '') {
+      newRadiusSlices[radiiSlice.name] = cornerRadius;
       return;
     }
 
@@ -70,22 +70,22 @@ export const syncBorderWidthVariants = (borderWidthsFrame: FrameNode) => {
     }
 
     if (borderWidthSlice.strokeWeight === figma.mixed) {
+      figma.notify('Mixed stroke weight is not allowed on Slices', { error: true });
       return;
     }
-
     const strokeWeight = borderWidthSlice.strokeWeight;
     const refIds = borderWidthSlice.getSharedPluginData(PLUGIN_DATA_NAMESPACE, borderWidthSlice.id).split('/#/');
-
-    if (refIds[0] === '') {
-      newBorderWidthSlices[borderWidthSlice.name] = strokeWeight;
-      return;
-    }
 
     if (existentBorderWidthSlices[borderWidthSlice.name]) {
       figma.notify(`The ${borderWidthSlice.name} variant on Border widths already exist, please use a unique name`, {
         error: true,
         timeout: 2000,
       });
+      return;
+    }
+
+    if (refIds[0] === '') {
+      newBorderWidthSlices[borderWidthSlice.name] = strokeWeight;
       return;
     }
 

--- a/src/plugin/utils/utils.test.ts
+++ b/src/plugin/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { mockGetNodeById } from '../../../__mocks__/figmaMock';
-import { mockPageNode } from '../../../__mocks__/mockUtils';
+import { mockNode } from '../../../__mocks__/mockUtils';
 import { PLUGIN_DATA_NAMESPACE, PluginDataKeys, Slices } from '../../_shared/constants';
 import {
   createInstances,
@@ -136,7 +136,7 @@ describe('deleteNodesById', () => {
 
 describe('saveCurrentBoxVariants', () => {
   it('should call setSharedPluginData with expected params', () => {
-    const themePage = mockPageNode();
+    const themePage = mockNode<PageNode>();
     const refIds = { S: '11:11/#/22:22', M: '33:33/#/44:44' };
     saveCurrentBoxVariants({ themePage, pluginKey: PluginDataKeys.currentRadiiVariants, refIds });
 

--- a/src/plugin/utils/utils.test.ts
+++ b/src/plugin/utils/utils.test.ts
@@ -1,5 +1,14 @@
-import { PLUGIN_DATA_NAMESPACE, Slices } from '../../_shared/constants';
-import { createInstances, getVariantCombinations, setRefs, updateVariantName } from './utils';
+import { mockGetNodeById } from '../../../__mocks__/figmaMock';
+import { mockPageNode } from '../../../__mocks__/mockUtils';
+import { PLUGIN_DATA_NAMESPACE, PluginDataKeys, Slices } from '../../_shared/constants';
+import {
+  createInstances,
+  deleteNodesById,
+  getVariantCombinations,
+  saveCurrentBoxVariants,
+  setRefs,
+  updateVariantName,
+} from './utils';
 
 describe('get variant combinations', () => {
   it('should return expected combinations', () => {
@@ -105,5 +114,36 @@ describe('setRefs', () => {
 
     expect(mockSetSharedPluginData).toBeCalledTimes(1);
     expect(mockSetSharedPluginData).toBeCalledWith(PLUGIN_DATA_NAMESPACE, '123:11', '444:32/#/222:12');
+  });
+});
+
+describe('deleteNodesById', () => {
+  it('should not crash if getNodeById returns null', () => {
+    mockGetNodeById.mockReturnValue(null);
+    deleteNodesById(['11:22', '22:33']);
+  });
+  it('should call remove for each node with provided id', () => {
+    const mockRemove = jest.fn();
+    mockGetNodeById.mockReturnValue({ remove: mockRemove });
+
+    deleteNodesById(['11:22', '22:33']);
+
+    expect(mockRemove).toBeCalledTimes(2);
+    expect(mockGetNodeById).toBeCalledWith('11:22');
+    expect(mockGetNodeById).toBeCalledWith('22:33');
+  });
+});
+
+describe('saveCurrentBoxVariants', () => {
+  it('should call setSharedPluginData with expected params', () => {
+    const themePage = mockPageNode();
+    const refIds = { S: '11:11/#/22:22', M: '33:33/#/44:44' };
+    saveCurrentBoxVariants({ themePage, pluginKey: PluginDataKeys.currentRadiiVariants, refIds });
+
+    expect(themePage.setSharedPluginData).toBeCalledWith(
+      PLUGIN_DATA_NAMESPACE,
+      PluginDataKeys.currentRadiiVariants,
+      JSON.stringify(refIds)
+    );
   });
 });

--- a/src/plugin/utils/utils.ts
+++ b/src/plugin/utils/utils.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_DATA_NAMESPACE, Slices } from '../../_shared/constants';
+import { PLUGIN_DATA_NAMESPACE, PluginDataKeys, Slices } from '../../_shared/constants';
 
 export type RefIds = Partial<Record<Slices, Record<string, string>>>;
 
@@ -127,4 +127,31 @@ export const setRefs = ({
       slice.setSharedPluginData(PLUGIN_DATA_NAMESPACE, slice.id, refIds[slice.name]);
     }
   });
+};
+
+/**
+ * Call remove() for each node found with provided id.
+ *
+ * Doesn't do anything if a node with such id is not found
+ *
+ * @param ids list of ids to be removed
+ */
+export const deleteNodesById = (ids: string[]) => {
+  ids.map((id) => {
+    const node = figma.getNodeById(id);
+    if (node !== null) {
+      node.remove();
+    }
+  });
+};
+
+type SaveCurrentBoxVariantsOptions = {
+  themePage: PageNode;
+  refIds: Record<string, string>;
+  pluginKey: PluginDataKeys;
+};
+
+export const saveCurrentBoxVariants = ({ themePage, refIds, pluginKey }: SaveCurrentBoxVariantsOptions) => {
+  const currentVariants = JSON.stringify(refIds);
+  themePage.setSharedPluginData(PLUGIN_DATA_NAMESPACE, pluginKey, currentVariants);
 };


### PR DESCRIPTION
# Proposed changes

Implmented logic to keep trace of existing box variants and used it to detect any deleted slice variants. In this way we can easily remove the related box variants and keep everything syncronised

closes #12

## Types of changes

- [x] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✅ Tests (added tests for an existing feature)
- [ ] 📚 Chore / Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [x] :scissors: I have ensured that the PR is concise and broken down if needed
- [x] 👀 I have read the [README](../README.md) doc
- [x] 🧪 I have added tests that prove my fix is effective or that my feature works
- [ ] 📚 I have added necessary documentation (if appropriate)
- [x] 🔀 Any dependent changes have been merged and published in downstream modules
