### PR TITLE
feat: create a error system to notify the user when something goes wr…

### DIFF
--- a/src/plugin/syncTheme/syncTheme.test.ts
+++ b/src/plugin/syncTheme/syncTheme.test.ts
@@ -87,4 +87,12 @@ describe('syncTheme', () => {
 
     expect(mockAppendChild).toBeCalledTimes([...mockRadiiCombinations, ...mockBorderWidthCombinations].length);
   });
+  test('Should call appendChild for each new variants created', () => {
+    mockRootChildren.push({
+      ...mockDefaultPage,
+    });
+    syncTheme({ type: ActionTypes.syncTheme });
+
+    expect(mockAppendChild).toBeCalledTimes([...mockRadiiCombinations, ...mockBorderWidthCombinations].length);
+  });
 });

--- a/src/plugin/syncTheme/utils.ts
+++ b/src/plugin/syncTheme/utils.ts
@@ -195,7 +195,6 @@ export type ErrorMap = Record<ErrorType, string[]>;
  * @param errorMap - Object containing the error types and their messages
  */
 export const notifyErrorMessages = (errorMap: ErrorMap) => {
-  console.log(Object.values(errorMap));
   Object.values(errorMap)
     .flat()
     .forEach((errorMessage) => {
@@ -212,7 +211,7 @@ function createWrongElementMessage({
   currentType: string;
   sliceName: string;
 }) {
-  return `The ${sliceName} slice accepts only ${acceptedElementType} elements, you're also using ${currentType}`;
+  return `The ${sliceName} slice accepts only ${acceptedElementType} elements. Please remove ${currentType} elements`;
 }
 
 function createDuplicatedSliceNameMessage({ variantName, sliceName }: { variantName: string; sliceName: string }) {

--- a/src/plugin/syncTheme/utils.ts
+++ b/src/plugin/syncTheme/utils.ts
@@ -7,26 +7,42 @@ import { deleteNodesById, updateVariantName } from '../utils/utils';
  *
  * It returns the existing and new variants added
  */
-export const syncRadiiVariants = (radiiFrame: FrameNode) => {
+export const syncRadiiVariants = (radiiFrame: FrameNode, errorMap: ErrorMap) => {
   const newRadiusSlices: Record<string, number> = {};
   const existentRadiusSlices: Record<string, number> = {};
+  const acceptedElementType: SceneNode['type'] = 'RECTANGLE';
 
   radiiFrame.children.map((radiiSlice) => {
-    if (radiiSlice.type !== 'RECTANGLE') {
+    if (radiiSlice.type !== acceptedElementType) {
+      generateAndRecordErrorMessage({
+        errorMap,
+        errorType: ErrorType.WRONG_ELEMENT_TYPE,
+        values: {
+          acceptedElementType,
+          currentType: radiiSlice.type,
+          sliceName: Slices.Radius,
+        },
+      });
       return;
     }
+
     const cornerRadius = radiiSlice.cornerRadius;
     const refIds = radiiSlice.getSharedPluginData(PLUGIN_DATA_NAMESPACE, radiiSlice.id).split('/#/');
 
     if (cornerRadius === figma.mixed) {
-      figma.notify('Mixed border radius is not allowed on Slices', { error: true });
+      generateAndRecordErrorMessage({
+        errorType: ErrorType.MIXED_SLICE_VALUES,
+        errorMap,
+        values: { sliceName: Slices.Radius, variantName: radiiSlice.name },
+      });
       return;
     }
 
     if (existentRadiusSlices[radiiSlice.name]) {
-      figma.notify(`The ${radiiSlice.name} variant on Radii already exist, please use a unique name`, {
-        error: true,
-        timeout: 2000,
+      generateAndRecordErrorMessage({
+        errorType: ErrorType.DUPLICATED_SLICE_NAME,
+        errorMap,
+        values: { sliceName: Slices.Radius, variantName: radiiSlice.name },
       });
       return;
     }
@@ -60,27 +76,49 @@ export const syncRadiiVariants = (radiiFrame: FrameNode) => {
  *
  * It returns the existing and new variants added
  */
-export const syncBorderWidthVariants = (borderWidthsFrame: FrameNode) => {
+export const syncBorderWidthVariants = (borderWidthsFrame: FrameNode, errorMap: ErrorMap) => {
   const newBorderWidthSlices: Record<string, number> = {};
   const existentBorderWidthSlices: Record<string, number> = {};
 
+  const acceptedElementType: SceneNode['type'] = 'LINE';
   borderWidthsFrame.children.map((borderWidthSlice) => {
-    if (borderWidthSlice.type !== 'LINE') {
+    if (borderWidthSlice.type !== acceptedElementType) {
+      generateAndRecordErrorMessage({
+        errorMap,
+        errorType: ErrorType.WRONG_ELEMENT_TYPE,
+        values: {
+          acceptedElementType,
+          currentType: borderWidthSlice.type,
+          sliceName: Slices.BorderWidth,
+        },
+      });
       return;
     }
 
     if (borderWidthSlice.strokeWeight === figma.mixed) {
-      figma.notify('Mixed stroke weight is not allowed on Slices', { error: true });
+      generateAndRecordErrorMessage({
+        errorMap,
+        errorType: ErrorType.MIXED_SLICE_VALUES,
+        values: {
+          sliceName: Slices.BorderWidth,
+          variantName: borderWidthSlice.name,
+        },
+      });
       return;
     }
     const strokeWeight = borderWidthSlice.strokeWeight;
     const refIds = borderWidthSlice.getSharedPluginData(PLUGIN_DATA_NAMESPACE, borderWidthSlice.id).split('/#/');
 
     if (existentBorderWidthSlices[borderWidthSlice.name]) {
-      figma.notify(`The ${borderWidthSlice.name} variant on Border widths already exist, please use a unique name`, {
-        error: true,
-        timeout: 2000,
+      generateAndRecordErrorMessage({
+        errorMap,
+        errorType: ErrorType.DUPLICATED_SLICE_NAME,
+        values: {
+          sliceName: Slices.BorderWidth,
+          variantName: borderWidthSlice.name,
+        },
       });
+
       return;
     }
 
@@ -142,3 +180,64 @@ export const checkAndRemoveDeletedSlices = ({
 
   return updatedCurrentVariants;
 };
+
+export enum ErrorType {
+  WRONG_ELEMENT_TYPE = 'wrongElementType',
+  MIXED_SLICE_VALUES = 'mixedSliceValues',
+  DUPLICATED_SLICE_NAME = 'duplicatedSliceName',
+}
+
+export type ErrorMap = Record<ErrorType, string[]>;
+
+/**
+ * Notify the user of each error found stored in the errorMap
+ *
+ * @param errorMap - Object containing the error types and their messages
+ */
+export const notifyErrorMessages = (errorMap: ErrorMap) => {
+  console.log(Object.values(errorMap));
+  Object.values(errorMap)
+    .flat()
+    .forEach((errorMessage) => {
+      figma.notify(`⚠️ Warning: ${errorMessage}`, { timeout: 4000 });
+    });
+};
+
+function createWrongElementMessage({
+  acceptedElementType,
+  currentType,
+  sliceName,
+}: {
+  acceptedElementType: string;
+  currentType: string;
+  sliceName: string;
+}) {
+  return `The ${sliceName} slice accepts only ${acceptedElementType} elements, you're also using ${currentType}`;
+}
+
+function createDuplicatedSliceNameMessage({ variantName, sliceName }: { variantName: string; sliceName: string }) {
+  return `The ${variantName} variant on ${sliceName} already exist, please use a unique name`;
+}
+
+function createMixedSliceValuesMessage({ variantName, sliceName }: { variantName: string; sliceName: string }) {
+  return `You're using mixed ${sliceName} in ${variantName}. Please use a single value`;
+}
+
+const warningMessageGenerators = {
+  [ErrorType.WRONG_ELEMENT_TYPE]: createWrongElementMessage,
+  [ErrorType.DUPLICATED_SLICE_NAME]: createDuplicatedSliceNameMessage,
+  [ErrorType.MIXED_SLICE_VALUES]: createMixedSliceValuesMessage,
+};
+
+export function generateAndRecordErrorMessage<T extends ErrorType>({
+  errorType,
+  errorMap,
+  values,
+}: {
+  errorType: T;
+  errorMap: ErrorMap;
+  values: Parameters<typeof warningMessageGenerators[T]>[0];
+}) {
+  const selectedMessage = warningMessageGenerators[errorType](values as any);
+  errorMap[errorType].push(selectedMessage);
+}


### PR DESCRIPTION
# Proposed changes
create an error system to notify the user when something goes wrong in the syncTheme function

closes #16 

## Types of changes

- [X] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (added tests for an existing feature)
- [ ] 📚 Chore / Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [X] :scissors: I have ensured that the PR is concise and broken down if needed
- [X] 👀 I have read the [README](../README.md) doc
- [X] 🧪 I have added tests that prove my fix is effective or that my feature works
- [ ] 📚 I have added necessary documentation (if appropriate)
- [X] 🔀 Any dependent changes have been merged and published in downstream modules
